### PR TITLE
Change version to 2.0.0

### DIFF
--- a/code.json
+++ b/code.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.1",
+  "version": "2.0.0",
   "agency": "EOP",
   "releases": [
     {


### PR DESCRIPTION
The version __2.0.1__ is a release candidate that is currently not being used. The latest `code.json` schema version is __2.0.0__.

Using the version __2.0.2__ is causing the `code.gov` harvester to throw an error saying it does not recognize the version.